### PR TITLE
Změna kalendáře

### DIFF
--- a/_teams/regiony/praha.md
+++ b/_teams/regiony/praha.md
@@ -36,7 +36,7 @@ Možnosti zapojení:
 * Přijďte se podívat na **Pirátská úterý**, což jsou pravidelné
   přednášky pro veřejnost, v Pirátském centru od 18:00 hodin.
 
-Podívejte se na konkrétní termíny akcí v [kalendáři]({{ '/pripoj-se/kalendar/' | relative_url }}),
+Podívejte se na konkrétní termíny akcí v [kalendáři](https://praha.pirati.cz/pripoj-se/kalendar/  ),
 abyste se ujistili, že akce bude.
 
 Více informací na krajském webu [praha.pirati.cz](https://praha.pirati.cz).


### PR DESCRIPTION
Změna odkazu na kalendář z celostátního na pražský na pražském webu.