### PR TITLE
Update nela-chudova.md

### DIFF
--- a/_people/nela-chudova.md
+++ b/_people/nela-chudova.md
@@ -13,3 +13,9 @@ profiles:
   facebook: https://www.facebook.com/nel.chudova
   twitter: https://twitter.com/Nel_chudova
 ---
+
+Bc. Nela Chudová (*26.6.1994) je odborná asistentka v oblasti mezinárodních vztahů a PR místopředsedy PS PČR Vojtěcha Pikala. 
+
+Nela Chudová pochází z malebné vesnice uprostřed jesenických lesů, z [Karlovy Studánky](http://www.horskelazne.cz/). Vystudovala sportovní gymnázium ve Vrbně pod Pradědem a následně absolvovala obor [politologie a evropská studia](https://kpes.upol.cz/) na Univerzitě Palackého v Olomouci. V současnosti pokračuje navazujícím magisterským studium v oboru politologie se specializací v oblasti politického marketingu taktéž na UP. Během své profesní kariéry absolvovala mj. stáž na [Stále misi České republiky](https://www.mzv.cz/geneva) při Úřadovně OSN a ostatních mezinárodních organizacích v Ženevě. Angažuje se jako dobrovolník na [MFF Jeden Svět](https://jedensvet.cz/2018/) či každoročně pořádá [vánoční akce pro klienty Léčeben dlouhodobě nemocných](http://vanocevsem.cz/nas-tym/). Ve volném čase nejraději cestuje, čte, hraje deskovky a navštěvuje [Hospodské kvízy](http://www.hospodskykviz.cz/#jakfunguje). 
+
+S Piráty začala spolupracovat po úspěšném absolvování výběrového řízení na pozici politického poradce v lednu 2017.


### PR DESCRIPTION
+Bc. Nela Chudová (*26.6.1994) je odborná asistentka v oblasti mezinárodních vztahů a PR místopředsedy PS PČR Vojtěcha Pikala. 
+
+Nela Chudová pochází z malebné vesnice uprostřed jesenických lesů, z [Karlovy Studánky](http://www.horskelazne.cz/). Vystudovala sportovní gymnázium ve Vrbně pod Pradědem a následně absolvovala obor [politologie a evropská studia](https://kpes.upol.cz/) na Univerzitě Palackého v Olomouci. V současnosti pokračuje navazujícím magisterským studium v oboru politologie se specializací v oblasti politického marketingu taktéž na UP. Během své profesní kariéry absolvovala mj. stáž na [Stále misi České republiky](https://www.mzv.cz/geneva) při Úřadovně OSN a ostatních mezinárodních organizacích v Ženevě. Angažuje se jako dobrovolník na [MFF Jeden Svět](https://jedensvet.cz/2018/) či každoročně pořádá [vánoční akce pro klienty Léčeben dlouhodobě nemocných](http://vanocevsem.cz/nas-tym/). Ve volném čase nejraději cestuje, čte, hraje deskovky a navštěvuje [Hospodské kvízy](http://www.hospodskykviz.cz/#jakfunguje). 
+
+S Piráty začala spolupracovat po úspěšném absolvování výběrového řízení na pozici politického poradce v lednu 2017.